### PR TITLE
Avoid flushing buffers when seeking with SeekFrom::Start is a no-op

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,12 +223,10 @@ impl<R: Read + Seek> Seek for BufReader<R> {
                 }
             }
             SeekFrom::Start(n) => {
-                // Get difference between actual and requested position
-                let n_bytes = n.checked_sub(self.absolute_pos).unwrap_or(0);
-                // Check if number of bytes is within buffer range
-                match n_bytes > 0 && n_bytes < self.available() as u64 {
-                    true => self.seek_forward(n_bytes as usize),
-                    false => self.sync_and_flush(pos)
+                // Check difference between actual and requested position
+                match n.checked_sub(self.absolute_pos) {
+                    Some(n_bytes) => self.seek_forward(n_bytes as usize),
+                    None => self.sync_and_flush(pos)
                 }
             }
             _ => self.sync_and_flush(pos)


### PR DESCRIPTION
Do not flush internal buffers when seeking with SeekFrom::Start resolves
to the current position. Also removes the extra check whether the target
position falls into the buffered range as this is already handled by
seek_forward.

Signed-off-by: Tobias Rapp <t.rapp@noa-archive.com>